### PR TITLE
Fixes a bug where batched API calls bleed params.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,9 +62,11 @@
         }
 
         var promise = new Promise(function(resolve, reject) {
+            var _params = mergeRecursive({}, this._options.params);
+
             this._queue.push({
                 method: method,
-                params: mergeRecursive(this._options.params, params || {}),
+                params: mergeRecursive(_params, params || {}),
                 deferred: {resolve: resolve, reject: reject}
             });
 

--- a/test/unit/lib/index_test.js
+++ b/test/unit/lib/index_test.js
@@ -123,6 +123,21 @@ describe('Tagged API', function() {
             this.http.post.calledOnce.should.be.true;
         });
 
+        // WTA-537
+        it('does not bleed parameters', function() {
+            this.api.execute("im.send", {
+                param1: "foo",
+                param2: "bar"
+            });
+            this.api.execute("im.doStuff", {
+                param3: "bar",
+                param4: "baz"
+            });
+            this.clock.tick(1);
+            this.http.post.lastCall.args[0].body.should.not.match(/method=im.send.*param3=bar/);
+            this.http.post.lastCall.args[0].body.should.not.match(/method=im.doStuff.*param1=foo/g);
+        });
+
         it('makes new post call after clock tick', function() {
             var expectedBody = "\nmethod=im.send&param1=foo&param2=bar\n";
             this.api.execute("im.send", {


### PR DESCRIPTION
When API calls are batched, the parameters bleed into other other calls. This fixes the bug by ensuring that each call gets its own parameters object.
