### PR TITLE
Sets AJAX header when using angular adapter.

### DIFF
--- a/lib/http_adapter/angular.js
+++ b/lib/http_adapter/angular.js
@@ -14,7 +14,8 @@
         var headers = {
             'x-tagged-client-id': req.clientId,
             'x-tagged-client-url': this._$window.location.href,
-            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-Requested-With': 'XMLHttpRequest'
         };
         return this._$http.post(req.url, req.body, {
             timeout: 10000,

--- a/test/unit/lib/http_adapter/angular_test.js
+++ b/test/unit/lib/http_adapter/angular_test.js
@@ -90,5 +90,16 @@ describe('Angular Adapter', function() {
             this.$http.post.calledOnce.should.be.true;
             this.$http.post.lastCall.args[2].headers.should.have.property('Content-Type', expectedContentType);
         });
+
+        it('sets ajax header', function() {
+            var url = 'http://example.com/foo';
+            var body = 'post body';
+            this.adapter.post({
+                url: url,
+                body: body
+            });
+            this.$http.post.calledOnce.should.be.true;
+            this.$http.post.lastCall.args[2].headers.should.have.property('X-Requested-With', 'XMLHttpRequest');
+        });
     });
 });


### PR DESCRIPTION
Helps prevent certain types of XSRF attacks by passing the `X-Requested-With` header and validating on the server.