### PR TITLE
Adds ability to set a max queue size.

### DIFF
--- a/test/unit/lib/index_test.js
+++ b/test/unit/lib/index_test.js
@@ -145,6 +145,29 @@ describe('Tagged API', function() {
             this.http.post.calledOnce.should.be.true;
         });
 
+        describe('max queue size', function() {
+            it('immediately sends off http request if queue exceeds max queue size', function() {
+                this.api.setMaxQueueSize(3);
+                this.api.execute("one");
+                this.api.execute("two");
+                this.http.post.calledOnce.should.be.false;
+                this.api.execute("three");
+                this.http.post.calledOnce.should.be.true;
+                this.api.execute("four");
+                this.api.execute("five");
+                this.http.post.calledTwice.should.be.false;
+                this.clock.tick(1);
+                this.http.post.calledTwice.should.be.true;
+            });
+
+            it('can be retrieved', function() {
+                this.api.setMaxQueueSize(3);
+                this.api.getMaxQueueSize().should.equal(3);
+                this.api.setMaxQueueSize(10);
+                this.api.getMaxQueueSize().should.equal(10);
+            });
+        });
+
         // WTA-537
         it('does not bleed parameters', function() {
             this.api.execute("im.send", {


### PR DESCRIPTION
When the queue size hits the maximum, the HTTP request will be processed immediately to clear the queue. This can create help with performance when the number of simultaneous calls exceeds 15.