### PR TITLE
Enables keep-alive when using the node adapter.

### DIFF
--- a/lib/http_adapter/node.js
+++ b/lib/http_adapter/node.js
@@ -1,4 +1,13 @@
 var Promise = require('bluebird');
+var KeepAliveAgent = require('agentkeepalive');
+
+// @see https://github.com/node-modules/agentkeepalive
+var agent = new KeepAliveAgent({
+    maxSockets: Infinity,       // default is Infinity
+    maxFreeSockets: 256,        // default is 256
+    timeout: 60000,             // default is keepAliveTimeout * 2
+    keepAliveTimeout: 30000     // free socket keepalive for 30 seconds
+});
 
 var Http = function(request) {
     this._request = request || require('request');
@@ -32,7 +41,8 @@ Http.prototype.post = function(req) {
         url: req.url,
         body: req.body,
         timeout: this._timeout,
-        headers: headers
+        headers: headers,
+        agent: agent
     }).then(extractRequest);
 };
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "url": "https://github.com/ifwe/api-client-js/issues"
   },
   "dependencies": {
+    "agentkeepalive": "2.0.3",
     "bluebird": "^2.2.2",
     "btoa": "^1.1.2",
-    "request": "^2.37.0",
-    "grunt-contrib-uglify": "^0.5.0"
+    "grunt-contrib-uglify": "^0.5.0",
+    "request": "^2.37.0"
   },
   "homepage": "https://github.com/ifwe/api-client-js",
   "devDependencies": {

--- a/test/unit/lib/http_adapter/node_test.js
+++ b/test/unit/lib/http_adapter/node_test.js
@@ -70,6 +70,17 @@ describe('Node HTTP Adapter', function() {
             this.request.post.lastCall.args[0].headers.should.have.property('x-tagged-client-secret', clientSecret);
         });
 
+        it('uses keepalive agent', function() {
+            var KeepAliveAgent = require('agentkeepalive');
+            this.http.post({
+                url: this.url,
+                body: this.body
+            });
+            this.request.post.calledOnce.should.be.true;
+            this.request.post.lastCall.args[0].should.have.property('agent');
+            this.request.post.lastCall.args[0].agent.should.be.instanceOf(KeepAliveAgent);
+        });
+
         it('sets content-type header', function() {
             var expectedContentType = 'application/x-www-form-urlencoded; charset=UTF-8';
             var url = 'http://example.com/foo';


### PR DESCRIPTION
Uses [`agentkeepalive`](https://github.com/node-modules/agentkeepalive) to reuse socket connections.