### PR TITLE
Adds high-resolution timestamp support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,8 @@
             this._queue.push({
                 method: method,
                 params: mergeRecursive(_params, params || {}),
-                deferred: {resolve: resolve, reject: reject}
+                deferred: {resolve: resolve, reject: reject},
+                timeStart: getHighResolutionTimeStamp()
             });
 
             if (this._maxQueueSize && this._queue.length >= this._maxQueueSize) {
@@ -138,7 +139,8 @@
             cookies: this._options.cookies,
             clientId: this._options.clientId,
             secret: this._options.secret,
-            headers: this._options.headers || {}
+            headers: this._options.headers || {},
+            timeStart: this._queueTimeStart
         })
         .then(parseResponseBody)
         .then(resolveQueue.bind(this, this._queue))
@@ -281,6 +283,29 @@
         // one-line string to represent the API call.
         return params.join('&');
     };
+
+    var getHighResolutionTimeStamp = function() {
+        if (process && typeof process.hrtime === 'function') {
+            // Node environment
+            return process.hrtime();
+        } else if (window && window.performance && typeof window.performance.now === 'function') {
+            // Browser envorinment that supports high-resolution timestamps
+            // Must convert from float to nodejs-flavored high-resolution timestamp
+            // @see https://nodejs.org/api/process.html#process_process_hrtime_time
+            // @see https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+            var now = window.performance.now().toString();
+            if (now.match(/^[0-9]+\.[0-9]+$/)) {
+                return now.split('.').map(function(value) {
+                    return parseInt(value);
+                });
+            }
+        }
+
+        // High resolution timestamps are not supported,
+        // or returned an unexpected result.
+        // Fall back to low-resolution timestamp.
+        return [new Date().getTime(), 0];
+    }
 
     var parameterize = function(key, value) {
         var type = typeof value;


### PR DESCRIPTION
Each API call that is added to the queue now records the current timestamp in a high-resolution format. The event handler can be used to fetch this value after each API call completes. For example:

```js
let api = new TaggedAPI();
api.on('ok', (request, response) => {
  let diff = process.hrtime(request.timeStart);
  console.log(`API call took ${diff[0] * 1e9 + diff[1]} nanoseconds`);
});
```

New tests:

```
  TaggedAPI
    on
      queue timing
        in node environments
          ✓ includes timeStart as high-resolution timestamp
        in browser environments that support performance.now()
          ✓ includes timeStart as high-resolution timestamp
        in browser environments that return strange values for performance.now()
          ✓ falls back to low-resolution timeStart in high-resolution format
        in browser environments that do not support-high resolution timestamps
          ✓ falls back to low-resolution timeStart in high-resolution format
```