### PR TITLE
Expose node adapter

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1,0 +1,2 @@
+module.exports = require('./index');
+module.exports.NodeAdapter = require('./http_adapter/node');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tagged-api",
   "version": "0.3.2",
   "description": "API client for Tagged with support for nodejs and angularjs",
-  "main": "lib/index.js",
+  "main": "lib/node.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
Allows the node adapter to be accessible when `require()`ing this package in nodejs.